### PR TITLE
ci: Add uv virtualenv and build steps to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - name: Checkout code
+      uses: actions/checkout@v4
 
     - name: Install uv
       uses: astral-sh/setup-uv@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,13 +16,24 @@ jobs:
     - name: Install uv
       uses: astral-sh/setup-uv@v6
 
-    - name: Install package and test dependencies
+    - name: Create uv virtualenv
+      run: uv venv
+
+    - name: Build wheel
       run: |
-        uv pip install .[test]  # Assumes optional 'test' deps are listed in pyproject.toml
-        uv pip install pytest
+        source .venv/bin/activate
+        uv build
+
+    - name: Install test dependencies
+      run: |
+        source .venv/bin/activate
+        uv pip install --group test
+        uv pip install dist/*.whl
 
     - name: Run tests
-      run: pytest
+      run: |
+        source .venv/bin/activate
+        .venv/bin/pytest --pyargs vg
 
     - name: Build package
       run: uv build


### PR DESCRIPTION
Changes:
- Added a "Checkout code" step to `ci.yml` for clarity.
- Added `Create uv virtualenv` step to `release.yml`.
- Added `Build wheel` step to `release.yml`.
- Added `Install test dependencies` step to `release.yml` using uv pip install --group test
- Modified `release.yml` to activate the uv virtualenv before running tests and installing packages.
- Updated test execution in `release.yml` to use the uv virtualenv.